### PR TITLE
Uses point for /autocomplete and viewport for /search

### DIFF
--- a/src/main/java/com/mapzen/pelias/BoundingBox.java
+++ b/src/main/java/com/mapzen/pelias/BoundingBox.java
@@ -1,22 +1,22 @@
 package com.mapzen.pelias;
 
 public class BoundingBox {
-    public String minLat;
-    public String minLon;
-    public String maxLat;
-    public String maxLon;
+    public double minLat;
+    public double minLon;
+    public double maxLat;
+    public double maxLon;
 
     public BoundingBox(double minLat, double minLon, double maxLat, double maxLon) {
-        if(((maxLat - minLat) > 0.0) && ((maxLon - minLon) > 0.0)) {
-            this.minLat = Double.toString(minLat);
-            this.minLon = Double.toString(minLon);
-            this.maxLat = Double.toString(maxLat);
-            this.maxLon = Double.toString(maxLon);
+        if (((maxLat - minLat) > 0.0) && ((maxLon - minLon) > 0.0)) {
+            this.minLat = minLat;
+            this.minLon = minLon;
+            this.maxLat = maxLat;
+            this.maxLon = maxLon;
         } else {
-            this.minLat = Double.toString(maxLat);
-            this.minLon = Double.toString(maxLon);
-            this.maxLat = Double.toString(minLat);
-            this.maxLon = Double.toString(minLon);
+            this.minLat = maxLat;
+            this.minLon = maxLon;
+            this.maxLat = minLat;
+            this.maxLon = minLon;
         }
     }
 }

--- a/src/main/java/com/mapzen/pelias/Pelias.java
+++ b/src/main/java/com/mapzen/pelias/Pelias.java
@@ -27,6 +27,7 @@ public class Pelias {
     private void initService(String serviceEndpoint) {
         RestAdapter restAdapter = new RestAdapter.Builder()
                 .setEndpoint(serviceEndpoint)
+                .setLogLevel(RestAdapter.LogLevel.FULL)
                 .build();
         this.service = restAdapter.create(PeliasService.class);
     }
@@ -45,43 +46,24 @@ public class Pelias {
         return instance;
     }
 
-    public void suggest(String query, String lat, String lon, Callback<Result> callback) {
-        service.getSuggest(query, lat, lon, apiKey,  callback);
-    }
-
     public void suggest(String query, Callback<Result> callback) {
-        service.getSuggest(query, locationProvider.getLat(), locationProvider.getLon(),apiKey,  callback);
+        suggest(query, locationProvider.getLat(), locationProvider.getLon(), callback);
     }
 
-    public void search(String query, String lat, String lon, BoundingBox box,
-                       Callback<Result> callback) {
-        search(query, lat, lon, box.minLon, box.minLat,
-                box.maxLon, box.maxLat, callback);
+    public void suggest(String query, double lat, double lon, Callback<Result> callback) {
+        service.getSuggest(query, lat, lon, apiKey, callback);
     }
 
-    public void search(String query, BoundingBox box,
-                       Callback<Result> callback) {
-        search(query, box.minLon, box.minLat, box.maxLon, box.maxLat, callback);
+    public void search(String query, Callback<Result> callback) {
+        search(query, locationProvider.getBoundingBox(), callback);
     }
 
-    public void search(String query, String lat, String lon, String minLon, String minLat,
-                       String maxLon, String maxLat, Callback<Result> callback) {
-        service.getSearch(query, lat, lon, minLon, minLat, maxLon, maxLat, apiKey, callback);
+    public void search(String query, BoundingBox box, Callback<Result> callback) {
+        service.getSearch(query, box.minLat, box.minLon, box.maxLat, box.maxLon, apiKey, callback);
     }
 
-    public void search(String query,String minLon, String minLat, String maxLon,
-                       String maxLat, Callback<Result> callback) {
-        service.getSearch(query, locationProvider.getLat(), locationProvider.getLon(),
-                minLon, minLat, maxLon, maxLat, apiKey, callback);
-    }
-
-
-    public void reverse(String lat, String lon, Callback<Result> callback) {
+    public void reverse(double lat, double lon, Callback<Result> callback) {
         service.getReverse(lat, lon, apiKey, callback);
-    }
-
-    public void doc(String type, String id, Callback<Result> callback) {
-        service.getDoc(type + ":" + id, apiKey,  callback);
     }
 
     public void setLocationProvider(PeliasLocationProvider locationProvider) {

--- a/src/main/java/com/mapzen/pelias/PeliasLocationProvider.java
+++ b/src/main/java/com/mapzen/pelias/PeliasLocationProvider.java
@@ -1,6 +1,7 @@
 package com.mapzen.pelias;
 
 public interface PeliasLocationProvider {
-    public String getLat();
-    public String getLon();
+    public double getLat();
+    public double getLon();
+    public BoundingBox getBoundingBox();
 }

--- a/src/main/java/com/mapzen/pelias/PeliasService.java
+++ b/src/main/java/com/mapzen/pelias/PeliasService.java
@@ -8,27 +8,32 @@ import retrofit.http.Query;
 
 public interface PeliasService {
     @GET("/autocomplete")
-    void getSuggest(@Query("text") String query,
-                    @Query("focus.point.lat") String lat,
-                    @Query("focus.point.lon") String lon,
-                    @Query("api_key") String key, Callback<Result> callback);
+    void getSuggest(
+            @Query("text") String query,
+            @Query("focus.point.lat") double lat,
+            @Query("focus.point.lon") double lon,
+            @Query("api_key") String key,
+            Callback<Result> callback);
 
     @GET("/search")
-    void getSearch(@Query("text") String query,
-                   @Query("focus.point.lat") String lat,
-                   @Query("focus.point.lon") String lon,
-                   @Query("focus.viewport.min_lon") String minLon,
-                   @Query("focus.viewport.min_lat") String minLat,
-                   @Query("focus.viewport.max_lon") String maxLon,
-                   @Query("focus.viewport.max_lat") String maxLat,
-                   @Query("api_key") String key, Callback<Result> callback);
+    void getSearch(
+            @Query("text") String query,
+            @Query("focus.viewport.min_lat") double minLat,
+            @Query("focus.viewport.min_lon") double minLon,
+            @Query("focus.viewport.max_lat") double maxLat,
+            @Query("focus.viewport.max_lon") double maxLon,
+            @Query("api_key") String key,
+            Callback<Result> callback);
 
     @GET("/reverse")
-    void getReverse(@Query("point.lat") String lat,
-                    @Query("point.lon") String lon,
-                    @Query("api_key") String key, Callback<Result> callback);
+    void getReverse(
+            @Query("point.lat") double lat,
+            @Query("point.lon") double lon,
+            @Query("api_key") String key,
+            Callback<Result> callback);
 
     @GET("/place")
     void getDoc(@Query("id") String typeAndId,
-                @Query("api_key") String key, Callback<Result> callback);
+            @Query("api_key") String key,
+            Callback<Result> callback);
 }

--- a/src/main/java/com/mapzen/pelias/widget/PeliasSearchView.java
+++ b/src/main/java/com/mapzen/pelias/widget/PeliasSearchView.java
@@ -1,13 +1,5 @@
 package com.mapzen.pelias.widget;
 
-import com.mapzen.pelias.BoundingBox;
-import com.mapzen.pelias.Pelias;
-import com.mapzen.pelias.R;
-import com.mapzen.pelias.SavedSearch;
-import com.mapzen.pelias.SimpleFeature;
-import com.mapzen.pelias.gson.Feature;
-import com.mapzen.pelias.gson.Result;
-
 import android.content.Context;
 import android.os.ResultReceiver;
 import android.support.v7.widget.SearchView;
@@ -19,6 +11,13 @@ import android.widget.AdapterView;
 import android.widget.EditText;
 import android.widget.HeaderViewListAdapter;
 import android.widget.ListView;
+
+import com.mapzen.pelias.Pelias;
+import com.mapzen.pelias.R;
+import com.mapzen.pelias.SavedSearch;
+import com.mapzen.pelias.SimpleFeature;
+import com.mapzen.pelias.gson.Feature;
+import com.mapzen.pelias.gson.Result;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -62,11 +61,9 @@ public class PeliasSearchView extends SearchView implements SearchView.OnQueryTe
     private Pelias pelias;
     private Callback<Result> callback;
     private OnSubmitListener onSubmitListener;
-    private BoundingBox boundingBox;
 
     public PeliasSearchView(Context context) {
         super(context);
-        boundingBox = new BoundingBox(0.0, 0.0, 0.0, 0.0);
         disableDefaultSoftKeyboardBehaviour();
         setOnQueryTextListener(this);
     }
@@ -137,14 +134,10 @@ public class PeliasSearchView extends SearchView implements SearchView.OnQueryTe
         }
     }
 
-    public void setBoundingBox(BoundingBox bbox) {
-      boundingBox = bbox;
-    }
-
     @Override
     public boolean onQueryTextSubmit(String query) {
         if (pelias != null) {
-            pelias.search(query,boundingBox,callback);
+            pelias.search(query, callback);
         }
 
         if (savedSearch != null) {

--- a/src/test/java/com/mapzen/pelias/PeliasTest.java
+++ b/src/test/java/com/mapzen/pelias/PeliasTest.java
@@ -25,7 +25,7 @@ public class PeliasTest {
     Pelias peliasWithMock;
     TestCallback callback;
     PeliasService mock;
-    String apiKey = "";
+    String apiKey = "test_key";
 
     @Captor
     @SuppressWarnings("unused")
@@ -37,45 +37,43 @@ public class PeliasTest {
         callback = new TestCallback();
         mock = Mockito.mock(PeliasService.class);
         peliasWithMock = new Pelias(mock);
-    }
-
-    @Test
-    public void doc_getDocument() throws Exception {
-        peliasWithMock.doc("osmnode", "15", callback);
-        verify(mock).getDoc(eq("osmnode:15"), eq(apiKey), cb.capture());
+        peliasWithMock.setApiKey(apiKey);
     }
 
     @Test
     public void search_getSearch() throws Exception {
-        peliasWithMock.search("test", "1", "2", "3", "4", "5", "6", callback);
-        verify(mock).getSearch(eq("test"), eq("1"), eq("2"), eq("3"), eq("4"), eq("5"), eq("6"), eq(apiKey), cb.capture());
+        BoundingBox boundingBox = new BoundingBox(1.0, 2.0, 3.0 ,4.0);
+        peliasWithMock.search("test", boundingBox, callback);
+        verify(mock).getSearch(eq("test"), eq(1.0), eq(2.0), eq(3.0), eq(4.0), eq(apiKey),
+                cb.capture());
     }
 
     @Test
     public void search_getSearchWithLocationProvider() throws Exception {
         peliasWithMock.setLocationProvider(new TestLocationProvider());
-        peliasWithMock.search("test","1", "2", "3", "4", callback);
-        verify(mock).getSearch(eq("test"), eq("1.0"), eq("2.0"), eq("1"), eq("2"), eq("3"), eq("4"), eq(apiKey), cb.capture());
+        peliasWithMock.search("test", callback);
+        verify(mock).getSearch(eq("test"), eq(3.0), eq(4.0), eq(5.0), eq(6.0), eq(apiKey),
+                cb.capture());
     }
 
     @Test
     public void suggest_getSuggest() throws Exception {
-        peliasWithMock.suggest("test", "1", "2", callback);
-        verify(mock).getSuggest(eq("test"), eq("1"), eq("2"), eq(apiKey), cb.capture());
+        peliasWithMock.suggest("test", 1.0, 2.0, callback);
+        verify(mock).getSuggest(eq("test"), eq(1.0), eq(2.0), eq(apiKey), cb.capture());
     }
 
     @Test
     public void suggest_getSuggestWithLocationProvider() throws Exception {
         peliasWithMock.setLocationProvider(new TestLocationProvider());
         peliasWithMock.suggest("test", callback);
-        verify(mock).getSuggest(eq("test"), eq("1.0"), eq("2.0"),eq(apiKey), cb.capture());
+        verify(mock).getSuggest(eq("test"), eq(1.0), eq(2.0),eq(apiKey), cb.capture());
     }
 
     @Test
-    public void reverse_getReverseGeocodingWithLocationProvider() throws Exception {
+    public void reverse_getReverseGeocode() throws Exception {
         peliasWithMock.setLocationProvider(new TestLocationProvider());
-        peliasWithMock.reverse("30.0", "30.0", callback);
-        verify(mock).getReverse(eq("30.0"), eq("30.0"), eq(apiKey), cb.capture());
+        peliasWithMock.reverse(30.0, 40.0, callback);
+        verify(mock).getReverse(eq(30.0), eq(40.0), eq(apiKey), cb.capture());
     }
 
     @Test
@@ -85,7 +83,7 @@ public class PeliasTest {
         server.enqueue(response);
         server.play();
         Pelias pelias = Pelias.getPeliasWithEndpoint(server.getUrl("/").toString());
-        pelias.suggest("test", "1", "2", callback);
+        pelias.suggest("test", 1.0, 2.0, callback);
         RecordedRequest request = server.takeRequest();
         assertThat(request.getPath()).contains("/autocomplete");
         server.shutdown();
@@ -102,12 +100,16 @@ public class PeliasTest {
     }
 
     public static class TestLocationProvider implements PeliasLocationProvider {
-        @Override public String getLat() {
-            return "1.0";
+        @Override public double getLat() {
+            return 1.0;
         }
 
-        @Override public String getLon() {
-            return "2.0";
+        @Override public double getLon() {
+            return 2.0;
+        }
+
+        @Override public BoundingBox getBoundingBox() {
+            return new BoundingBox(3.0, 4.0, 5.0, 6.0);
         }
     }
 }

--- a/src/test/java/com/mapzen/pelias/widget/PeliasSearchViewTest.java
+++ b/src/test/java/com/mapzen/pelias/widget/PeliasSearchViewTest.java
@@ -166,26 +166,24 @@ public class PeliasSearchViewTest {
 
     private class TestPeliasService implements PeliasService {
         @Override public void getSuggest(@Query("text") String query,
-                                         @Query("focus.point.lat") String lat,
-                                         @Query("focus.point.lon") String lon,
+                                         @Query("focus.point.lat") double lat,
+                                         @Query("focus.point.lon") double lon,
                                          @Query("api_key") String key, Callback<Result> callback) {
             callback.success(new Result(), null);
         }
 
         @Override public void getSearch(@Query("text") String query,
-                                        @Query("focus.point.lat") String lat,
-                                        @Query("focus.point.lon") String lon,
-                                        @Query("focus.viewport.min_lon") String minLon,
-                                        @Query("focus.viewport.min_lat") String minLat,
-                                        @Query("focus.viewport.max_lon") String maxLon,
-                                        @Query("focus.viewport.max_lat") String maxLat,
+                                        @Query("focus.viewport.min_lon") double minLon,
+                                        @Query("focus.viewport.min_lat") double minLat,
+                                        @Query("focus.viewport.max_lon") double maxLon,
+                                        @Query("focus.viewport.max_lat") double maxLat,
                                         @Query("api_key") String key, Callback<Result> callback) {
             callback.success(new Result(), null);
 
         }
 
-        @Override public void getReverse(@Query("point.lat") String lat,
-                                         @Query("point.lon") String lon,
+        @Override public void getReverse(@Query("point.lat") double lat,
+                                         @Query("point.lon") double lon,
                                          @Query("api_key") String key, Callback<Result> callback) {
             callback.success(new Result(), null);
         }


### PR DESCRIPTION
* Simplify `Pelias` request builder methods
* More explicit API param types (uses `double` for coordinates rather than `String`)
* Search request uses bounding box (viewport) only
* Remove /doc endpoint

Closes #16 