### PR TITLE
Adds focus change listener

### DIFF
--- a/src/main/java/com/mapzen/pelias/widget/PeliasSearchView.java
+++ b/src/main/java/com/mapzen/pelias/widget/PeliasSearchView.java
@@ -61,6 +61,7 @@ public class PeliasSearchView extends SearchView implements SearchView.OnQueryTe
     private Pelias pelias;
     private Callback<Result> callback;
     private OnSubmitListener onSubmitListener;
+    private OnFocusChangeListener onPeliasFocusChangeListener;
 
     public PeliasSearchView(Context context) {
         super(context);
@@ -86,6 +87,11 @@ public class PeliasSearchView extends SearchView implements SearchView.OnQueryTe
                     listView.setAnimation(slideOut);
                     postDelayed(hideImeRunnable, 300);
                     setOnQueryTextListener(null);
+                }
+
+                // Notify secondary listener
+                if (onPeliasFocusChangeListener != null) {
+                    onPeliasFocusChangeListener.onFocusChange(view, hasFocus);
                 }
             }
         });
@@ -233,6 +239,18 @@ public class PeliasSearchView extends SearchView implements SearchView.OnQueryTe
 
     public void setCallback(Callback<Result> callback) {
         this.callback = callback;
+    }
+
+    /**
+     * This should be used over {@link #setOnQueryTextFocusChangeListener(OnFocusChangeListener)}
+     * since {@link #setAutoCompleteListView(ListView)} relies on this method to control visibility
+     * of the autocomplete suggestion list. Events will be forwarded by the built-in listener.
+     *
+     * @param onPeliasFocusChangeListener the listener to be invoked when the query text view focus
+     * changes.
+     */
+    public void setOnPeliasFocusChangeListener(OnFocusChangeListener onPeliasFocusChangeListener) {
+        this.onPeliasFocusChangeListener = onPeliasFocusChangeListener;
     }
 
     /**

--- a/src/test/java/com/mapzen/pelias/widget/PeliasSearchViewTest.java
+++ b/src/test/java/com/mapzen/pelias/widget/PeliasSearchViewTest.java
@@ -176,6 +176,16 @@ public class PeliasSearchViewTest {
         assertThat(listener.submit).isTrue();
     }
 
+    @Test
+    public void setOnPeliasFocusChangeListener_shouldNotifyListener() throws Exception {
+        AutoCompleteListView listView = new AutoCompleteListView(ACTIVITY);
+        TestOnFocusChangeListener listener = new TestOnFocusChangeListener();
+        peliasSearchView.setAutoCompleteListView(listView);
+        peliasSearchView.setOnPeliasFocusChangeListener(listener);
+        shadowOf(getQueryTextView()).setViewFocus(true);
+        assertThat(listener.hasFocus).isTrue();
+    }
+
     private AutoCompleteTextView getQueryTextView() {
         final LinearLayout linearLayout1 = (LinearLayout) peliasSearchView.getChildAt(0);
         final LinearLayout linearLayout2 = (LinearLayout) linearLayout1.getChildAt(2);
@@ -261,6 +271,14 @@ public class PeliasSearchViewTest {
         private boolean submit;
         @Override public void onSubmit() {
             submit = true;
+        }
+    }
+
+    private class TestOnFocusChangeListener implements View.OnFocusChangeListener {
+        private boolean hasFocus;
+
+        @Override public void onFocusChange(View v, boolean hasFocus) {
+            this.hasFocus = hasFocus;
         }
     }
 }


### PR DESCRIPTION
Adds ability to set a focus change listener using `setOnPeliasFocusChangeListener(View.OnFocusChangeListener)` that does not interfere with the built-in focus change listener used to control visibility of the `AutoCompleteListView`.